### PR TITLE
Fixed pip installation for submodules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,4 @@ app = [
 line-length = 120
 
 [tool.setuptools]
-packages = ["simple_einet"]
+packages = ["simple_einet", "simple_einet.layers", "simple_einet.layers.distributions"]


### PR DESCRIPTION
### Issue
Installing from git+https://github.com/braun-steven/simple-einet doesn't install the submodules "layers" and "layers.distribution" wouldn't add simple_einet.layers to the environment, upon checking the setup for package, it wasn't included in the setup file hence the sub-directories weren't bundled with the main package.

### Solution
Add the submodules to the package list, if it was a .py file using setuptools we could also use setuptools.find_packages(), but for toml I believe we need to list all sub-modules to be in pip installable package

### Changes
Included "simple_einet.layers", "simple_einet.layers.distributions" in the list of modules to be packaged